### PR TITLE
Updates for iOS13

### DIFF
--- a/PulseCQTNC.xcodeproj/project.pbxproj
+++ b/PulseCQTNC.xcodeproj/project.pbxproj
@@ -1362,7 +1362,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PulseCQTNC/Pods-PulseCQTNC-resources.sh\"\n";
+			shellScript = "/bin/sh \"${PODS_ROOT}/Target Support Files/Pods-PulseCQTNC/Pods-PulseCQTNC-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		7A2C0700BD2CFCC7DB5354A5 /* [CP] Check Pods Manifest.lock */ = {
@@ -1692,7 +1692,7 @@
 					"${PODS_ROOT}/**",
 				);
 				INFOPLIST_FILE = PulseCQTNC/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1735,7 +1735,7 @@
 					"${PODS_ROOT}/**",
 				);
 				INFOPLIST_FILE = PulseCQTNC/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/PulseCQTNC/APRSManager.m
+++ b/PulseCQTNC/APRSManager.m
@@ -7,7 +7,7 @@
 //
 
 #import "APRSManager.h"
-#include <ao/ao.h>
+#include "ao.h"
 #include <stdint.h>
 #include <string.h>
 #include <stdarg.h>

--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ This app will be updated with better message handling.
 
 ## Dependencies
 
-Please install **libao** with Mac Ports:
-sudo port install libao
+Please install **libao** with [homebrew](https://brew.sh/):
+
+```console
+$ brew install libao
+```
 
 ## Authors
 


### PR DESCRIPTION
I'm new to iOS development, so no hard feelings if this doesn't fix things the "right way."

But with these changes I'm able to build and run on iOS13.

Fixes #1 

NB: I use homebrew (not MacPorts), so I had to change the `ao` import path. It seems like homebrew is by far the more popular MacOS package manager these days; I think using it instead of MacPorts might help encourage contributions. Additionally, it doesn't require installing `libao` with elevated permissions.